### PR TITLE
Small patch bump to fix CircleCI badge

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pegjs-import",
-  "version": "1.2.7",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invisible/pegjs-import",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Import other PEG files into a PEG.js grammar.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR is just prompting CircleCI to run tests again on master.
Previously we had `pegjs-import` be the actual fork and the `pegjs-imp` a standalone repo.
The fork was deleted and `pegjs-imp` was renamed to `pegjs-import`.